### PR TITLE
[FPGA] Changing the deprecated noinit to new no_init

### DIFF
--- a/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/src/lsu_control.cpp
+++ b/DirectProgramming/DPC++FPGA/Tutorials/Features/lsu_control/src/lsu_control.cpp
@@ -67,7 +67,7 @@ void KernelRun(const std::vector<int> &input_data, const size_t &input_size,
     buffer input_buffer(input_data);
 
     auto e_p = q.submit([&](handler &h) {
-      accessor output_a(output_buffer, h, write_only, noinit);
+      accessor output_a(output_buffer, h, write_only, no_init);
       accessor input_a(input_buffer, h, read_only);
 
       // Kernel that uses the prefetch LSU
@@ -84,7 +84,7 @@ void KernelRun(const std::vector<int> &input_data, const size_t &input_size,
     });
 
     auto e_b = q.submit([&](handler &h) {
-      accessor output_a(output_buffer, h, write_only, noinit);
+      accessor output_a(output_buffer, h, write_only, no_init);
       accessor input_a(input_buffer, h, read_only);
       
       // Kernel that uses the burst-coalesced LSU
@@ -101,7 +101,7 @@ void KernelRun(const std::vector<int> &input_data, const size_t &input_size,
     });
 
     auto e_d = q.submit([&](handler &h) {
-      accessor output_a(output_buffer, h, write_only, noinit);
+      accessor output_a(output_buffer, h, write_only, no_init);
       accessor input_a(input_buffer, h, read_only);
       
       // Kernel that uses the default LSUs


### PR DESCRIPTION
Signed-off-by: aditi.kumaraswamy <aditikum@scc823113.sc.intel.com>

# Existing Sample Changes
## Description

LSU control FPGA tutorial uses the deprecated "noinit", changing to the new "no_init" 
Fixes Issue# 
ONSAM-1391

## External Dependencies

List any external dependencies created as a result of this change.

## Type of change

Please delete options that are not relevant. Add a 'X' to the one that is applicable. 

- [X ] Bug fix (non-breaking change which fixes an issue)
- [X ] Implement fixes for ONSAM Jiras 

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Command Line
